### PR TITLE
Make the link to BuildingBSD.pdf clickable

### DIFF
--- a/articles/sysadmin/builds_ccache_memcached.md
+++ b/articles/sysadmin/builds_ccache_memcached.md
@@ -83,6 +83,6 @@ With builtin support for ccache(1) within the FreeBSD base build system, the nex
 ADDITIONAL READING
 ------------------
 - The original METAMODE talk given by sjg during BSDCan 2011:
-  http://www.crufty.net/sjg/blog/BuildingBSD.pdf
+  [http://www.crufty.net/sjg/blog/BuildingBSD.pdf](http://www.crufty.net/sjg/blog/BuildingBSD.pdf).
 - ccache.conf(5) lists various options that could be used to tune/adjust ccache behavior.
 - memcached(1) lists options that could be used to enable (SASL) authentication.


### PR DESCRIPTION
It is highlighted when viewed from the GitHub web interface but it is not highlighted as an URL on the website itself.